### PR TITLE
When "Form not found", retry.

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -394,8 +394,10 @@ class GmailAutoBccHandler {
 
         this.debug(this.formsEnabled);
         if (!this.formsEnabled[formElement.id]) {
-            this.debug("Form not found returning early");
-            return;
+            this.debug("Form not found. Trying again in 250ms");
+            setTimeout(() => {
+                this.updateCcAndBccRecipients(recipient, formElement);
+            }, 250);
         }
 
         // Check if email rules are disabled for this form

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -398,6 +398,7 @@ class GmailAutoBccHandler {
             setTimeout(() => {
                 this.updateCcAndBccRecipients(recipient, formElement);
             }, 250);
+            return;
         }
 
         // Check if email rules are disabled for this form


### PR DESCRIPTION
In my experience, this fixes https://github.com/MyOutDeskLLC/auto-bcc/issues/6.

I initially tried 10ms, but it would retry many times before working.
At 100ms, it retries once or twice in rare cases.
At 250ms, I have yet to see it retry more than once.